### PR TITLE
Make footer responsive and refactor with tables at 600px

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -1,1 +1,63 @@
-<!-- ending -->
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+   <head>
+       <!-- NAME: ANNOUNCE -->
+       <!--[if gte mso 15]>
+       <xml>
+           <o:OfficeDocumentSettings>
+           <o:AllowPNG/>
+           <o:PixelsPerInch>96</o:PixelsPerInch>
+           </o:OfficeDocumentSettings>
+       </xml>
+       <![endif]-->
+       <meta charset="UTF-8">
+       <meta http-equiv="X-UA-Compatible" content="IE=edge">
+       <meta name="viewport" content="width=device-width, initial-scale=1">
+       <title>*|MC:SUBJECT|*</title>
+       <link rel="stylesheet" href="newsletter.css">
+   </head>
+   <body class="ef-body">
+       <center class="ef-wrapper">
+           <div class="ef-webkit">
+               <table class="ef-table ef-outer" align="center">
+                  
+                   <!-- Footer -->
+
+                   <tr>
+                       <td class="ef-td">
+                           <table class="ef-table" width="100%" style="margin-top: 50px;">
+                               <tr>
+                                    <td class="ef-td ef-footer">
+                                        <hr class="sk-horizontal">
+                                        <table class="ef-table ef-column ef-columnLogo" style="float: left;">
+                                            <tr>
+                                                <td class="ef-td ef-padding">
+                                                    <table class="ef-table ef-content">
+                                                        <tr>
+                                                            <td class="ef-td"><img class="ef-lightbulb" src="https://drive.google.com/uc?export=view&id=1gq2ARk8HOCKw9MBrUfrEYe3GJjHGyBta"></td>
+                                                        </tr>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <table class="ef-table ef-column ef-columnLogo" style="float: right;">
+                                           <tr>
+                                               <td class="ef-td ef-padding">
+                                                   <table class="ef-table ef-content">
+                                                           <td class="ef-td"><img class="ef-lightbulb" src="https://drive.google.com/uc?export=view&id=1gq2ARk8HOCKw9MBrUfrEYe3GJjHGyBta"></td>
+                                                       </tr>
+                                                   </table>
+                                               </td>
+                                           </tr>
+                                       </table>
+                                   </td>
+                               </tr>
+                           </table>
+                       </td>
+                   </tr>
+ 
+               </table>
+           </div>
+       </center>
+   </body>
+</html>

--- a/newsletter.css
+++ b/newsletter.css
@@ -269,7 +269,8 @@
 
 
 
-/* ELIAS - header.html */
+/* ELIAS */
+/* all */
 .ef-body {
     margin: 0;
     padding: 0;
@@ -308,7 +309,11 @@
     background-image: url('https://drive.google.com/uc?export=view&id=1dQKwKeUTLuZFi64MaGJNrTLPuv_t4wY1');
     background-repeat: repeat;
     background-size: 100%;
+
+    padding-bottom: 50px;
 }
+
+/* header.html */
 
 .ef-logo {
     background-color: #153641;
@@ -330,7 +335,7 @@
     max-width: 440px;
 }
 
-.ef-logo .ef-padding {
+.ef-padding {
     padding: 15px;
 }
 
@@ -345,7 +350,7 @@
     margin: auto;
 }
 
-.ef-logo .ef-lightbulb {
+.ef-lightbulb {
     width: 50;
     max-width: 50px;
 }
@@ -380,6 +385,21 @@
     margin-left: 10px;
 }
 
+/* footer.html */
+
+.ef-footer {
+    text-align: center;
+}
+
+.ef-footer .sk-horizontal {
+    border: .2vw solid #FFD807; 
+    width: 11.6675vw;
+}
+
+.ef-footer .ef-columnLogo {
+    max-width: 80px;
+}
+
  @media screen and (max-width: 600px) {
      .ef-logo .ef-columnLogo {
          max-width: 40px;
@@ -397,7 +417,7 @@
          font-size: 12px !important;
      }
 
-     .ef-logo .ef-lightbulb {
+     .ef-lightbulb {
          width: 32 !important;
          max-width: 32px !important;
      }


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 940408300
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes
What changes did you make?
- Added footer refactored as tables in footer.html
- Added responsive CSS for the footer in newsletter.css

### Testing
How did you confirm your changes worked? 
- Sent test emails and viewed on Desktop Gmail, Mobile Gmail, and Mobile Apple Mail to make sure that the changes worked
- Also made sure that old code did not get messed up
- Dark mode and Gmail responsiveness are still issues that have not been solved
- I checked responsiveness by adjusting the screen width in Chrome inspect options and resizing the window (the only thing changing sizes should be the horizontal rule above the lightbulbs)
- The side padding of the lightbulbs looked off at first but it matches those of the header logo
- Let me know if any sizes need to be changed!

### Confirmation of Change 
Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change.

| Desktop Gmail | Mobile Gmail | Mobile Apple Mail | Mobile Apple Mail (Dark) |
| --- | --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/56064410/104116642-340e6a80-52cf-11eb-9ac2-bbab655cd093.png) | ![File (3)](https://user-images.githubusercontent.com/56064410/104116643-3cff3c00-52cf-11eb-9044-d3be24dce2c5.jpg) | ![File (2)](https://user-images.githubusercontent.com/56064410/104116647-438db380-52cf-11eb-9a4a-80278664322b.jpg) | ![File (1)](https://user-images.githubusercontent.com/56064410/104116648-48526780-52cf-11eb-826a-25604c6664e1.jpg) |